### PR TITLE
Update Package.swift for Xcode 14.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .iOS(.v11),
     ],
     products: [
-        .library(name: "JSONView", type: .dynamic, targets: ["JSONView"]),
+        .library(name: "JSONView", targets: ["JSONView"]),
     ],
     targets: [
         .target(name: "JSONView", dependencies: []),


### PR DESCRIPTION
Hey @quentinfasquel,

Since Xcode 14.5, the `type: .dynamic` in Package.swift is a problem and doesn't works again with `-weak_framework SwiftUI` in project where is used the Swift Package, for the target below iOS 13.0.

By removing the type, the package works again ✨ 

